### PR TITLE
[공통] 커스텀 예외 추가

### DIFF
--- a/src/main/java/com/toongather/toongather/domain/member/service/MemberService.java
+++ b/src/main/java/com/toongather/toongather/domain/member/service/MemberService.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import com.toongather.toongather.global.common.error.custom.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -105,10 +107,10 @@ public class MemberService {
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
     if (!member.getTempCode().equals(tempCode)) {
-      throw new IllegalArgumentException("임시번호가 일치하지 않습니다.");
+      throw new MemberException.TempCodeInvalidException();
     }
     if (member.getTempCodeExpired().isBefore(LocalDateTime.now())) {
-      throw new IllegalArgumentException("임시번호가 만료되었습니다.");
+      throw new MemberException.TempCodeExpiredException();
     }
     member.updateTempCode(null, null);
     member.setMemberType(MemberType.ACTIVE);

--- a/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
@@ -7,6 +7,7 @@ import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
 import com.toongather.toongather.domain.webtoon.repository.GenreKeywordRepository;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
+import com.toongather.toongather.global.common.error.custom.WebtoonException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +38,7 @@ public class WebtoonService {
     @Transactional
     public void updateWebtoon(Long toonId, WebtoonRequest request) {
         Webtoon webtoon = webtoonRepository.findById(toonId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 웹툰이 존재하지 않습니다."));
+                .orElseThrow(WebtoonException.WebtoonNotFoundException::new);
 
         List<GenreKeyword> genreKeywords = getGenreKeywords(request);
         webtoon.update(request.getAge(), request.getSummary(), request.getStatus(), genreKeywords);
@@ -46,7 +47,7 @@ public class WebtoonService {
     @Transactional
     public void deleteWebtoon(Long toonId) {
         Webtoon webtoon = webtoonRepository.findById(toonId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 웹툰이 존재하지 않습니다."));
+                .orElseThrow(WebtoonException.WebtoonNotFoundException::new);
 
         webtoonRepository.delete(webtoon);
     }

--- a/src/main/java/com/toongather/toongather/global/common/error/CommonError.java
+++ b/src/main/java/com/toongather/toongather/global/common/error/CommonError.java
@@ -18,7 +18,10 @@ public enum CommonError {
   USER_NOT_ACTIVE(HttpStatus.UNAUTHORIZED,  "NOT_ACTIVE_USER"),
 
   //validation
-  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR")
+  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR"),
+
+  //webtoon
+  WEBTOON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 웹툰이 존재하지 않습니다."),
 
   ;
   private final HttpStatus status;

--- a/src/main/java/com/toongather/toongather/global/common/error/CommonError.java
+++ b/src/main/java/com/toongather/toongather/global/common/error/CommonError.java
@@ -20,8 +20,12 @@ public enum CommonError {
   //validation
   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR"),
 
+  //member
+  TEMP_CODE_INVALID(HttpStatus.BAD_REQUEST, "임시번호가 일치하지 않습니다."),
+  TEMP_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "임시번호가 만료되었습니다."),
+
   //webtoon
-  WEBTOON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 웹툰이 존재하지 않습니다."),
+  WEBTOON_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 웹툰이 존재하지 않습니다.")
 
   ;
   private final HttpStatus status;

--- a/src/main/java/com/toongather/toongather/global/common/error/CommonErrorInfo.java
+++ b/src/main/java/com/toongather/toongather/global/common/error/CommonErrorInfo.java
@@ -11,14 +11,12 @@ import lombok.NoArgsConstructor;
 public class CommonErrorInfo {
 
   private String path;
-  private String code;
   private String message;
 
   @Builder
-  public CommonErrorInfo(String code, String path, String message) {
-    this.code = code;
-    this.message = message;
+  public CommonErrorInfo(String path, String message) {
     this.path = path;
+    this.message = message;
   }
 
 }

--- a/src/main/java/com/toongather/toongather/global/common/error/custom/MemberException.java
+++ b/src/main/java/com/toongather/toongather/global/common/error/custom/MemberException.java
@@ -1,0 +1,23 @@
+package com.toongather.toongather.global.common.error.custom;
+
+import com.toongather.toongather.global.common.error.CommonError;
+import com.toongather.toongather.global.common.error.CommonRuntimeException;
+
+public class MemberException extends CommonRuntimeException {
+
+    public MemberException(CommonError error) {
+        super(error);
+    }
+
+    public static class TempCodeInvalidException extends MemberException {
+        public TempCodeInvalidException() {
+            super(CommonError.TEMP_CODE_INVALID);
+        }
+    }
+
+    public static class TempCodeExpiredException extends MemberException {
+        public TempCodeExpiredException() {
+            super(CommonError.TEMP_CODE_EXPIRED);
+        }
+    }
+}

--- a/src/main/java/com/toongather/toongather/global/common/error/custom/WebtoonException.java
+++ b/src/main/java/com/toongather/toongather/global/common/error/custom/WebtoonException.java
@@ -1,0 +1,17 @@
+package com.toongather.toongather.global.common.error.custom;
+
+import com.toongather.toongather.global.common.error.CommonError;
+import com.toongather.toongather.global.common.error.CommonRuntimeException;
+
+public class WebtoonException extends CommonRuntimeException {
+
+    public WebtoonException(CommonError error) {
+        super(error);
+    }
+
+    public static class WebtoonNotFoundException extends WebtoonException {
+        public WebtoonNotFoundException() {
+            super(CommonError.WEBTOON_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## 🐞 이슈
- 관련된 이슈 번호: #22 

## 🔨 PR 타입
- [x] ✨ 기능 추가
- [ ] ❌ 기능 삭제
- [ ] 🐛 버그 수정
- [x] 💡 리팩토링
- [ ] 🔧 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내역
- 커스텀 예외 추가
- 기존 코드 추가된 커스텀 예외 활용하도록 수정
- CommonErrorInfo 수정하여 응답에서 code 보이지 않도록 수정

## 💡 질문 공유
- 사용자 정의 응답 코드 보이지 않도록 저번 PR(#26)에서 수정 해주셨는데, 
CommonError에서 HttpStatus 작성하는게 좀 의미가 없다고 느껴져서 HttpStatus가 응답에 함께 보이도록 추가하는건 어떻게 생각하시나요??
- @youniejang 임시 코드 불일치, 만료 관련 exception은 고민하다 MemberService에서 사용하길래 MemberException 클래스로 만들었는데.. 수정하셔도 됩니다루~

close #22 
