### PR TITLE
[회원] service, repository 테스트 코드 작성 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     //test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 test {

--- a/src/main/java/com/toongather/toongather/domain/member/api/AuthApi.java
+++ b/src/main/java/com/toongather/toongather/domain/member/api/AuthApi.java
@@ -48,7 +48,7 @@ public class AuthApi {
       case EXPIRED :
         return new ResponseEntity("login need", HttpStatus.UNAUTHORIZED);
       case ACCESS :
-        MemberDTO member = memberService.findMemberById(id);
+        MemberDTO member = memberService.findMemberWithRoleById(id);
         //access token 발급
         if(member.getRefreshToken().equals(tokens.getRefreshToken())) {
           HttpHeaders httpHeaders = authService.setAccessTokenHeader(member);

--- a/src/main/java/com/toongather/toongather/domain/member/domain/Member.java
+++ b/src/main/java/com/toongather/toongather/domain/member/domain/Member.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -29,7 +28,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "MEMBER")
 @Entity
-@Getter @Setter
+@Getter
 @SequenceGenerator(
     name = "MEMBER_SEQ_GEN",
     sequenceName = "MEMBER_SEQ",
@@ -91,7 +90,8 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
   //생성자
   @Builder
-  public Member(String name, String password, String email, String phone, String nickName) {
+  public Member(Long memberId, String name, String password, String email, String phone, String nickName) {
+    this.id = memberId;
     this.name = name;
     this.email = email;
     this.phone = phone;
@@ -129,14 +129,21 @@ public class Member extends BaseTimeEntity implements UserDetails {
     this.tempCodeExpired = tempCodeExpired;
   }
 
+  public void updateActiveMember() {
+    this.memberType = MemberType.ACTIVE;
+    this.updateTempCode(null, null);
+  }
+
+  public void resetPassword(String password) {
+    this.password = password;
+  }
+
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
 
-    List<SimpleGrantedAuthority> collect = memberRoles.stream()
+    return memberRoles.stream()
         .map(entity -> new SimpleGrantedAuthority(entity.getRole().getName().name()))
         .collect(Collectors.toList());
-
-    return collect;
   }
 
   @Override

--- a/src/main/java/com/toongather/toongather/domain/member/dto/MemberDTO.java
+++ b/src/main/java/com/toongather/toongather/domain/member/dto/MemberDTO.java
@@ -5,6 +5,7 @@ import com.toongather.toongather.domain.member.domain.MemberType;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -45,7 +46,7 @@ public class MemberDTO {
   @Getter
   @Setter
   public static class LoginRequest {
-    @NotNull
+    @NotBlank
     @Email
     private String email;
     @NotEmpty
@@ -55,7 +56,7 @@ public class MemberDTO {
   @Getter
   @Setter
   public static class TempCodeRequest {
-    @NotNull
+    @NotBlank
     Long id;
 
     @NotNull
@@ -65,9 +66,9 @@ public class MemberDTO {
   @Getter
   @Setter
   public static class SearchMemberRequest {
-    @NotNull
+    @NotBlank
     private String name;
-    @NotNull
+    @NotBlank
     private String phone;
   }
 

--- a/src/main/java/com/toongather/toongather/domain/member/service/MemberService.java
+++ b/src/main/java/com/toongather/toongather/domain/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package com.toongather.toongather.domain.member.service;
 
 import com.toongather.toongather.domain.member.domain.Member;
-import com.toongather.toongather.domain.member.domain.MemberType;
 import com.toongather.toongather.domain.member.domain.Role;
 import com.toongather.toongather.domain.member.domain.RoleType;
 import com.toongather.toongather.domain.member.dto.JoinFormRequest;
@@ -11,12 +10,11 @@ import com.toongather.toongather.domain.member.repository.MemberRoleRepository;
 import com.toongather.toongather.domain.member.repository.RoleRepository;
 import com.toongather.toongather.global.common.error.CommonError;
 import com.toongather.toongather.global.common.error.CommonRuntimeException;
+import com.toongather.toongather.global.common.error.custom.MemberException;
 import java.time.LocalDateTime;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import com.toongather.toongather.global.common.error.custom.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -39,7 +37,7 @@ public class MemberService {
    * 회원가입
    */
   @Transactional
-  public Long join(JoinFormRequest dto) {
+  public Member join(JoinFormRequest dto) {
 
     //회원 저장
     Member member = Member.builder()
@@ -53,17 +51,16 @@ public class MemberService {
     //권한 조회
     Role role = roleRepository.findByName(RoleType.ROLE_USER);
     member.addMemberRoles(role);
-    memberRepository.save(member);
+    Member savedMember = memberRepository.save(member);
     memberRoleRepository.saveAll(member.getMemberRoles());
 
     //인증 메일 보내기
     LocalDateTime now = LocalDateTime.now();
     LocalDateTime tempExpired = now.plusMinutes(2);
     String tempCode = createCode();
-    member.updateTempCode(tempCode, tempExpired);
-    emailService.sendEmail("tempcode", tempCode, member.getEmail());
+    savedMember.updateTempCode(tempCode, tempExpired);
 
-    return member.getId();
+    return savedMember;
   }
 
   public MemberDTO loginMember(String email, String password) {
@@ -88,7 +85,7 @@ public class MemberService {
     return result;
   }
 
-  public MemberDTO findMemberById(Long id) {
+  public MemberDTO findMemberWithRoleById(Long id) {
     Member member = memberRepository.findMemberWithRole(id)
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     return new MemberDTO(member);
@@ -99,15 +96,16 @@ public class MemberService {
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
   }
-  
-  public void resetPasswordByEmail(String email) {
+
+  @Transactional
+  public String resetPasswordByEmail(String email) {
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
     String password = createCode();
-    member.setPassword(passwordEncoder.encode(password));
+    member.resetPassword(passwordEncoder.encode(password));
 
-    emailService.sendEmail("resetpwd", password, member.getEmail());
+    return password;
 
   }
 
@@ -119,15 +117,15 @@ public class MemberService {
     if (!member.getTempCode().equals(tempCode)) {
       throw new MemberException.TempCodeInvalidException();
     }
-    if (member.getTempCodeExpired().isBefore(LocalDateTime.now())) {
+    if (!member.getTempCodeExpired().isBefore(LocalDateTime.now())) {
       throw new MemberException.TempCodeExpiredException();
     }
-    member.updateTempCode(null, null);
-    member.setMemberType(MemberType.ACTIVE);
+
+    member.updateActiveMember();
   }
 
   @Transactional
-  public void reSendEmail(Long id) {
+  public void resendEmail(Long id) {
     Member member = memberRepository.findById(id)
         .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 

--- a/src/test/java/com/toongather/toongather/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/toongather/toongather/domain/member/api/MemberApiTest.java
@@ -11,13 +11,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.toongather.toongather.domain.member.domain.Member;
-import com.toongather.toongather.domain.member.domain.MemberType;
 import com.toongather.toongather.domain.member.dto.JoinFormRequest;
 import com.toongather.toongather.domain.member.dto.MemberDTO;
 import com.toongather.toongather.domain.member.dto.MemberDTO.LoginRequest;
 import com.toongather.toongather.domain.member.dto.MemberDTO.SearchMemberRequest;
 import com.toongather.toongather.domain.member.repository.MemberRepository;
 import com.toongather.toongather.domain.member.service.AuthService;
+import com.toongather.toongather.domain.member.service.EmailService;
 import com.toongather.toongather.domain.member.service.MemberService;
 import com.toongather.toongather.global.common.error.CommonError;
 import com.toongather.toongather.global.common.error.CommonRuntimeException;
@@ -54,27 +54,32 @@ class MemberApiTest {
   JwtTokenProvider jwtTokenProvider;
 
   @MockBean
+  EmailService emailService;
+
+  @MockBean
   AuthService authService;
 
   private MemberDTO member;
+
+  private Member memberEntity;
 
   private HttpHeaders httpHeaders;
 
   @BeforeEach
   void setUp() {
 
-    Member memberEntity = Member.builder()
+    memberEntity = Member.builder()
+        .memberId(1L)
         .name("test")
         .email("test@gmail.com")
         .phone("010-1234-5678")
         .password("1234")
         .nickName("test")
         .build();
-
-    memberEntity.setId(1L);
-    memberEntity.setMemberType(MemberType.ACTIVE);
+    memberEntity.updateActiveMember();
 
     member = new MemberDTO(memberEntity);
+
 
     httpHeaders = new HttpHeaders();
     httpHeaders.add("Authorization", "Bearer " + "token");
@@ -93,7 +98,7 @@ class MemberApiTest {
     joinForm.setNickName("test");
     joinForm.setPassword("1234");
 
-    given(memberService.join(ArgumentMatchers.any(JoinFormRequest.class))).willReturn(1L);
+    given(memberService.join(ArgumentMatchers.any(JoinFormRequest.class))).willReturn(memberEntity);
 
     //when
     //then

--- a/src/test/java/com/toongather/toongather/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.toongather.toongather.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.toongather.toongather.domain.member.domain.JoinType;
+import com.toongather.toongather.domain.member.domain.Member;
+import com.toongather.toongather.domain.member.domain.MemberType;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class MemberRepositoryTest {
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  @Test
+  @DisplayName("email을 통해 멤버를 찾는다")
+  void findByEmail() {
+
+    Member member = Member.builder()
+        .email("test@gmail.com")
+        .name("test")
+        .nickName("testnickname")
+        .phone("010-123-1234")
+        .password("1234")
+        .build();
+
+    memberRepository.save(member);
+
+    Optional<Member> result = memberRepository.findByEmail(member.getEmail());
+
+    assertThat(result).isNotNull();
+    assertThat(result.get().getEmail()).isEqualTo(member.getEmail());
+    assertThat(result.get().getName()).isEqualTo(member.getName());
+    assertThat(result.get().getJoinType()).isEqualTo(JoinType.NORMAL);
+    assertThat(result.get().getMemberType()).isEqualTo(MemberType.TEMP);
+
+  }
+
+}

--- a/src/test/java/com/toongather/toongather/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,257 @@
+package com.toongather.toongather.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.toongather.toongather.domain.member.domain.Member;
+import com.toongather.toongather.domain.member.domain.MemberType;
+import com.toongather.toongather.domain.member.domain.Role;
+import com.toongather.toongather.domain.member.domain.RoleType;
+import com.toongather.toongather.domain.member.dto.JoinFormRequest;
+import com.toongather.toongather.domain.member.dto.MemberDTO;
+import com.toongather.toongather.domain.member.repository.MemberRepository;
+import com.toongather.toongather.domain.member.repository.MemberRoleRepository;
+import com.toongather.toongather.domain.member.repository.RoleRepository;
+import com.toongather.toongather.global.common.error.custom.MemberException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private RoleRepository roleRepository;
+
+  @Mock
+  private MemberRoleRepository memberRoleRepository;
+
+  @Mock
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Mock
+  private EmailService emailService;
+
+  @InjectMocks
+  private MemberService memberService;
+
+  private Member memberEntity;
+
+  private MemberDTO memberDTO;
+
+  @BeforeEach
+  void setUp() {
+
+    memberEntity = Member.builder()
+        .memberId(1L)
+        .name("test")
+        .email("test@gmail.com")
+        .phone("010-1234-5678")
+        .password("1234")
+        .nickName("test")
+        .build();
+
+    memberEntity.addMemberRoles(Role.builder().name(RoleType.ROLE_USER).build());
+
+  }
+
+  @Test
+  @DisplayName("회원가입 성공")
+  void join() {
+    //given
+    JoinFormRequest request = new JoinFormRequest();
+    request.setName(memberEntity.getName());
+    request.setEmail(memberEntity.getEmail());
+    request.setPhone(memberEntity.getPhone());
+    request.setPassword(memberEntity.getPassword());
+    request.setNickName(memberEntity.getNickName());
+
+    Role role = Role.builder()
+        .name(RoleType.ROLE_USER)
+        .build();
+
+    given(passwordEncoder.encode(request.getPassword())).willReturn("1234");
+    given(roleRepository.findByName(RoleType.ROLE_USER)).willReturn(role);
+    given(memberRoleRepository.saveAll(any())).willReturn(List.of());
+
+    //when
+    when(memberRepository.save(any(Member.class))).thenAnswer(
+        invocation -> {
+          Member memberToSave = invocation.getArgument(0);
+          return Member.builder()
+              .memberId(1L)
+              .name(memberToSave.getName())
+              .email(memberToSave.getEmail())
+              .phone(memberToSave.getPhone())
+              .password(memberToSave.getPassword())
+              .nickName(memberToSave.getNickName())
+              .build();
+        }
+    );
+    Member member = memberService.join(request);
+
+    //then
+    assertThat(member.getId()).isNotNull();
+    verify(roleRepository).findByName(any());
+    verify(memberRoleRepository).saveAll(any());
+    verify(memberRepository).save(argThat(memberField -> {
+      //필드검증
+      return memberField.getName().equals("test") &&
+             memberField.getEmail().equals("test@gmail.com") &&
+             memberField.getPhone().equals("010-1234-5678") &&
+             memberField.getPassword().equals("1234") &&
+             memberField.getNickName().equals("test");
+    }));
+
+  }
+
+  @Test
+  @DisplayName("로그인 성공한다")
+  void loginSuccess() {
+    String email = memberEntity.getEmail();
+    String password = memberEntity.getPassword();
+
+    given(memberRepository.findByEmail(email)).willReturn(Optional.ofNullable(memberEntity));
+    given(passwordEncoder.matches(password, memberEntity.getPassword())).willReturn(true);
+
+    MemberDTO result = memberService.loginMember(email, password);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getName()).isEqualTo(memberEntity.getName());
+
+  }
+
+  @Test
+  @DisplayName("이름과 폰번호로 회원을 찾을 수 있다.")
+  void findMemberByNameAndPhone() {
+    // given
+    String name = "홍길동";
+    String phone = "010-1234-5678";
+
+    ConcurrentMap<String, Object> memberInfo = new ConcurrentHashMap<>();
+    memberInfo.put("email", memberEntity.getEmail());
+    memberInfo.put("id", 1L);
+    given(memberRepository.findByNameAndPhone(name, phone)).willReturn(
+        Optional.ofNullable(memberEntity));
+
+    ConcurrentMap<String, Object> result = memberService.findMemberByNameAndPhone(
+        name, phone);
+
+    // then
+    assertThat(result)
+        .isNotNull()
+        .containsEntry("email", memberEntity.getEmail())
+        .containsEntry("id", 1L);
+
+  }
+
+  @Test
+  @DisplayName("이름과 폰번호로 회원을 찾을 수 없어 에러를 던진다.")
+  void findMemberByNameAndPhoneFail() {
+    // given
+    String name = "홍길동";
+    String phone = "010-1234-5678";
+
+    given(memberRepository.findByNameAndPhone(name, phone)).willReturn(
+        Optional.empty());
+
+    // when
+    // then
+    assertThatThrownBy(() -> memberService.findMemberByNameAndPhone(name, phone))
+        .isInstanceOf(UsernameNotFoundException.class)
+        .hasMessage("사용자를 찾을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("id를 통해 회원과 권한을 찾는다")
+  void findMemberWithRoleById() {
+    // given
+    Long id = 1L;
+    given(memberRepository.findMemberWithRole(id)).willReturn(
+        Optional.ofNullable(memberEntity));
+
+    // when
+    MemberDTO result = memberService.findMemberWithRoleById(id);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getRoleNames()).contains(RoleType.ROLE_USER.name());
+
+  }
+
+  @Test
+  @DisplayName("이메일을 통해서 패스워드가 리셋된다")
+  void resetPasswordByEmail() {
+    String email = memberEntity.getEmail();
+
+    given(memberRepository.findByEmail(email)).willReturn(Optional.ofNullable(memberEntity));
+    given(passwordEncoder.encode(any())).willReturn(any());
+
+    String password = memberService.resetPasswordByEmail(email);
+
+    assertThat(password).isNotNull();
+    verify(passwordEncoder).encode(any());
+
+  }
+
+  @Test
+  @DisplayName("회원 id와 임시코드가 일치하면 정회원으로 변경된다")
+  void confirmMemberByTempCode() {
+    Long id = memberEntity.getId();
+    memberEntity.updateTempCode("temp", LocalDateTime.now());
+    String tempCode = "temp";
+
+    given(memberRepository.findById(id)).willReturn(Optional.ofNullable(memberEntity));
+
+    memberService.confirmMemberByTempCode(id, tempCode);
+
+    assertThat(memberEntity.getMemberType()).isEqualTo(MemberType.ACTIVE);
+
+  }
+
+  @Test
+  @DisplayName("회원 임시코드가 일치하지 않아 에러를 던진다")
+  void confirmMemberByTempCodeError() {
+    Long id = memberEntity.getId();
+    memberEntity.updateTempCode("temp", LocalDateTime.now());
+    String tempcode = "not-temp";
+
+    given(memberRepository.findById(id)).willReturn(Optional.ofNullable(memberEntity));
+
+    assertThatThrownBy(() -> memberService.confirmMemberByTempCode(id, tempcode))
+        .isInstanceOf(MemberException.class);
+
+  }
+
+  @Test
+  @DisplayName("메일을 보낸다")
+  void resendEmail() {
+    Long id = memberEntity.getId();
+    given(memberRepository.findById(id)).willReturn(Optional.ofNullable(memberEntity));
+    memberService.resendEmail(id);
+    verify(emailService).sendEmail(eq("tempcode"), any(), eq(memberEntity.getEmail()));
+
+  }
+
+
+}


### PR DESCRIPTION
## 🐞 이슈
- 관련된 이슈 번호:  #35 

## 🔨 PR 타입
- [ ] ✨ 기능 추가
- [ ] ❌ 기능 삭제
- [ ] 🐛 버그 수정
- [x] 💡 리팩토링
- [x] 🔧 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내역
- 작업한 내용을 간략히 작성해주세요.
  - 롬복 테스트 코드에서도 쓸수있도록 의존성 추가
  - service, repository 테스트 코드 추가
  - member 회원가입과 아이디 찾기 서비스에서 이메일 서비스 컨트롤러 계층으로 리팩토링, 이유는 service에서 이메일과 회원가입이 같은 트랜잭션으로 묶일 필요가 없다고 생각했습니다

## 💡 질문 공유
- 리뷰어분들께 질문하고 싶은 내용이 있다면 적어주세요.

close #35 
