### PR TITLE
[웹툰] 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/toongather/toongather/domain/webtoon/api/WebtoonController.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/api/WebtoonController.java
@@ -1,9 +1,14 @@
 package com.toongather.toongather.domain.webtoon.api;
 
 import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
 import com.toongather.toongather.domain.webtoon.service.WebtoonService;
+import com.toongather.toongather.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +18,11 @@ import org.springframework.web.bind.annotation.*;
 public class WebtoonController {
 
     private final WebtoonService webtoonService;
+
+    @GetMapping("/search")
+    public ApiResponse<Page<WebtoonSearchResponse>> searchAll(WebtoonSearchRequest request, Pageable pageable) {
+        return ApiResponse.ok("/webtoon/search", webtoonService.searchAll(request, pageable));
+    }
 
     // todo: @Valid 추가
     @PostMapping("/new")

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchRequest.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchRequest.java
@@ -1,0 +1,31 @@
+package com.toongather.toongather.domain.webtoon.dto;
+
+import com.toongather.toongather.domain.webtoon.domain.Age;
+import com.toongather.toongather.domain.webtoon.domain.Platform;
+import com.toongather.toongather.domain.webtoon.domain.WebtoonStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class WebtoonSearchRequest {
+    private String title;
+    private String author;
+    private Age age;
+    private WebtoonStatus status;
+    private Platform platform;
+    private List<Long> genreKeywords;
+    private WebtoonSortType sortType;
+
+    @Builder
+    public WebtoonSearchRequest(String title, String author, Age age, WebtoonStatus status, Platform platform, List<Long> genreKeywords, WebtoonSortType sortType) {
+        this.title = title;
+        this.author = author;
+        this.age = age;
+        this.status = status;
+        this.platform = platform;
+        this.genreKeywords = genreKeywords;
+        this.sortType = sortType;
+    }
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchRequest.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchRequest.java
@@ -15,17 +15,17 @@ public class WebtoonSearchRequest {
     private Age age;
     private WebtoonStatus status;
     private Platform platform;
-    private List<Long> genreKeywords;
+    private List<Long> genreKeywordIds;
     private WebtoonSortType sortType;
 
     @Builder
-    public WebtoonSearchRequest(String title, String author, Age age, WebtoonStatus status, Platform platform, List<Long> genreKeywords, WebtoonSortType sortType) {
+    public WebtoonSearchRequest(String title, String author, Age age, WebtoonStatus status, Platform platform, List<Long> genreKeywordIds, WebtoonSortType sortType) {
         this.title = title;
         this.author = author;
         this.age = age;
         this.status = status;
         this.platform = platform;
-        this.genreKeywords = genreKeywords;
+        this.genreKeywordIds = genreKeywordIds;
         this.sortType = sortType;
     }
 }

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchResponse.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchResponse.java
@@ -1,0 +1,31 @@
+package com.toongather.toongather.domain.webtoon.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.toongather.toongather.domain.webtoon.domain.Webtoon;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WebtoonSearchResponse {
+    private Long toonId;
+    private String title;
+    private String imgPath;
+
+    @Builder
+    @QueryProjection
+    public WebtoonSearchResponse(Long toonId, String title, String imgPath) {
+        this.toonId = toonId;
+        this.title = title;
+        this.imgPath = imgPath;
+    }
+
+    public static WebtoonSearchResponse of(Webtoon webtoon) {
+        return WebtoonSearchResponse.builder()
+                .toonId(webtoon.getToonId())
+                .title(webtoon.getTitle())
+                .imgPath(webtoon.getImgPath())
+                .build();
+    }
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSortType.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSortType.java
@@ -1,0 +1,13 @@
+package com.toongather.toongather.domain.webtoon.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WebtoonSortType {
+    TITLE_ASC("오름차순"),
+    TITLE_DESC("내림차순");
+
+    private final String text;
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepository.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface WebtoonRepository extends JpaRepository<Webtoon, Long> {
+public interface WebtoonRepository extends JpaRepository<Webtoon, Long>, WebtoonRepositoryCustom {
 
 }

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryCustom.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.toongather.toongather.domain.webtoon.repository;
+
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface WebtoonRepositoryCustom {
+    Page<WebtoonSearchResponse> searchAll(WebtoonSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
@@ -33,10 +33,10 @@ public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
                         webtoon.title,
                         webtoon.imgPath
                 ))
-                .distinct()
                 .from(webtoon)
-                .join(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
+                .leftJoin(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
                 .where(buildConditions(request))
+                .groupBy(webtoon.toonId)
                 .orderBy(createOrderSpecifier(request.getSortType()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
@@ -43,8 +43,7 @@ public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
                 .fetch();
 
         Long total = queryFactory
-                .select(webtoon.count())
-                .distinct()
+                .select(webtoon.toonId.countDistinct())
                 .from(webtoon)
                 .leftJoin(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
                 .where(buildConditions(request))

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
@@ -8,7 +8,7 @@ import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSortType;
-import com.toongather.toongather.domain.webtoon.dto.response.QWebtoonSearchResponse;
+import com.toongather.toongather.domain.webtoon.dto.QWebtoonSearchResponse;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -33,6 +33,7 @@ public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
                         webtoon.title,
                         webtoon.imgPath
                 ))
+                .distinct()
                 .from(webtoon)
                 .join(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
                 .where(buildConditions(request))
@@ -43,6 +44,7 @@ public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
 
         Long total = queryFactory
                 .select(webtoon.count())
+                .distinct()
                 .from(webtoon)
                 .leftJoin(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
                 .where(buildConditions(request))
@@ -66,7 +68,7 @@ public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
         builder.and(equalsIfNotNull(webtoon.age, request.getAge()));
         builder.and(equalsIfNotNull(webtoon.status, request.getStatus()));
         builder.and(equalsIfNotNull(webtoon.platform, request.getPlatform()));
-        builder.and(genreKeywordIdsIn(request.getGenreKeywords()));
+        builder.and(genreKeywordIdsIn(request.getGenreKeywordIds()));
 
         return builder;
     }

--- a/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryImpl.java
@@ -1,0 +1,96 @@
+package com.toongather.toongather.domain.webtoon.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.SimpleExpression;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSortType;
+import com.toongather.toongather.domain.webtoon.dto.response.QWebtoonSearchResponse;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.toongather.toongather.domain.webtoon.domain.QWebtoon.webtoon;
+import static com.toongather.toongather.domain.webtoon.domain.QWebtoonGenreKeyword.webtoonGenreKeyword;
+
+@RequiredArgsConstructor
+public class WebtoonRepositoryImpl implements WebtoonRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<WebtoonSearchResponse> searchAll(WebtoonSearchRequest request, Pageable pageable) {
+
+        List<WebtoonSearchResponse> webtoons = queryFactory
+                .select(new QWebtoonSearchResponse(
+                        webtoon.toonId,
+                        webtoon.title,
+                        webtoon.imgPath
+                ))
+                .from(webtoon)
+                .join(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
+                .where(buildConditions(request))
+                .orderBy(createOrderSpecifier(request.getSortType()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(webtoon.count())
+                .from(webtoon)
+                .leftJoin(webtoon.webtoonGenreKeywords, webtoonGenreKeyword)
+                .where(buildConditions(request))
+                .fetchOne();
+
+        return new PageImpl<>(webtoons, pageable, total);
+    }
+
+    private BooleanBuilder buildConditions(WebtoonSearchRequest request) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // (title contains OR author contains)
+        BooleanBuilder searchBuilder = new BooleanBuilder();
+        searchBuilder.or(containsIfNotEmpty(webtoon.title, request.getTitle()));
+        searchBuilder.or(containsIfNotEmpty(webtoon.author, request.getAuthor()));
+
+        if (searchBuilder.hasValue()) {
+            builder.and(searchBuilder);
+        }
+
+        builder.and(equalsIfNotNull(webtoon.age, request.getAge()));
+        builder.and(equalsIfNotNull(webtoon.status, request.getStatus()));
+        builder.and(equalsIfNotNull(webtoon.platform, request.getPlatform()));
+        builder.and(genreKeywordIdsIn(request.getGenreKeywords()));
+
+        return builder;
+    }
+
+    private BooleanExpression containsIfNotEmpty(StringExpression path, String value) {
+        return StringUtils.hasText(value) ? path.containsIgnoreCase(value) : null;
+    }
+
+    private <T> BooleanExpression equalsIfNotNull(SimpleExpression<T> path, T value) {
+        return value != null ? path.eq(value) : null;
+    }
+
+    private BooleanExpression genreKeywordIdsIn(List<Long> genreKeywordIds) {
+        return (genreKeywordIds != null && !genreKeywordIds.isEmpty())
+                ? webtoonGenreKeyword.genreKeyword.genreKeywordId.in(genreKeywordIds)
+                : null;
+    }
+
+    private OrderSpecifier<?> createOrderSpecifier(WebtoonSortType sortType) {
+        return switch (sortType) {
+            // todo: add more cases
+            case TITLE_ASC -> webtoon.title.asc();
+            case TITLE_DESC -> webtoon.title.desc();
+            default -> webtoon.title.asc();
+        };
+    }
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
@@ -4,11 +4,15 @@ package com.toongather.toongather.domain.webtoon.service;
 import com.toongather.toongather.domain.webtoon.domain.GenreKeyword;
 import com.toongather.toongather.domain.webtoon.domain.Webtoon;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
 import com.toongather.toongather.domain.webtoon.repository.GenreKeywordRepository;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
 import com.toongather.toongather.global.common.error.custom.WebtoonException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +25,10 @@ public class WebtoonService {
 
     private final GenreKeywordRepository genreKeywordRepository;
     private final WebtoonRepository webtoonRepository;
+
+    public Page<WebtoonSearchResponse> searchAll(WebtoonSearchRequest request, Pageable pageable) {
+        return webtoonRepository.searchAll(request, pageable);
+    }
 
     @Transactional
     public WebtoonCreateResponse createWebtoon(WebtoonRequest request) {

--- a/src/main/java/com/toongather/toongather/global/common/ApiResponse.java
+++ b/src/main/java/com/toongather/toongather/global/common/ApiResponse.java
@@ -2,6 +2,7 @@ package com.toongather.toongather.global.common;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ApiResponse<T> {
@@ -17,6 +18,19 @@ public class ApiResponse<T> {
     this.code = code;
     this.message = message;
     this.data = data;
+  }
+
+  public static <T> ApiResponse<T> of(HttpStatus status, String path, String message, T data) {
+    return ApiResponse.<T>builder()
+        .path(path)
+        .code(status.toString())
+        .message(message)
+        .data(data)
+        .build();
+  }
+
+  public static <T> ApiResponse<T> ok(String path, T data) {
+    return of(HttpStatus.OK, path, "success", data);
   }
 
 }

--- a/src/main/java/com/toongather/toongather/global/config/QuerydslConfig.java
+++ b/src/main/java/com/toongather/toongather/global/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.toongather.toongather.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/toongather/toongather/TestConfig.java
+++ b/src/test/java/com/toongather/toongather/TestConfig.java
@@ -1,0 +1,17 @@
+package com.toongather.toongather;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+public class TestConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/GenreKeywordRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/GenreKeywordRepositoryTest.java
@@ -4,19 +4,14 @@ import com.toongather.toongather.domain.webtoon.domain.GenreKeyword;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-class GenreKeywordRepositoryTest {
+class GenreKeywordRepositoryTest extends RepositoryTestSupport {
 
     @Autowired
     private GenreKeywordRepository genreKeywordRepository;

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/RepositoryTestSupport.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/RepositoryTestSupport.java
@@ -1,0 +1,12 @@
+package com.toongather.toongather.domain.webtoon.repository;
+
+import com.toongather.toongather.TestConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestConfig.class)
+public abstract class RepositoryTestSupport {
+}

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.toongather.toongather.domain.webtoon.repository;
 
-import com.toongather.toongather.TestConfig;
 import com.toongather.toongather.domain.webtoon.domain.*;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
@@ -10,9 +9,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,10 +26,7 @@ import static com.toongather.toongather.domain.webtoon.dto.WebtoonSortType.TITLE
 import static com.toongather.toongather.domain.webtoon.dto.WebtoonSortType.TITLE_DESC;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(TestConfig.class)
-class WebtoonRepositoryTest {
+class WebtoonRepositoryTest extends RepositoryTestSupport {
 
     @Autowired
     private WebtoonRepository webtoonRepository;

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
@@ -1,0 +1,153 @@
+package com.toongather.toongather.domain.webtoon.repository;
+
+import com.toongather.toongather.TestConfig;
+import com.toongather.toongather.domain.webtoon.domain.*;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.toongather.toongather.domain.webtoon.domain.Age.ALL;
+import static com.toongather.toongather.domain.webtoon.domain.Age.OVER15;
+import static com.toongather.toongather.domain.webtoon.domain.Platform.NAVER;
+import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.END;
+import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.ING;
+import static com.toongather.toongather.domain.webtoon.dto.WebtoonSortType.TITLE_ASC;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestConfig.class)
+class WebtoonRepositoryTest {
+
+    @Autowired
+    private WebtoonRepository webtoonRepository;
+
+    @Autowired
+    private GenreKeywordRepository genreKeywordRepository;
+
+    // 검색 조건 테스트를 위한 파라미터 소스
+    static Stream<Arguments> searchConditionsProvider() {
+        Stream<Arguments> argumentsStream = Stream.of(
+                // 테스트 케이스명, 검색 요청 객체, 예상 결과 수, 예상 첫 번째 결과 제목
+                Arguments.of("제목으로 검색",
+                        WebtoonSearchRequest.builder().title("치즈인더트랩").sortType(TITLE_ASC).build(),
+                        1, List.of("치즈인더트랩")),
+                Arguments.of("작가로 검색",
+                        WebtoonSearchRequest.builder().author("순끼").sortType(TITLE_ASC).build(),
+                        2, List.of("세기말 풋사과 보습학원", "치즈인더트랩")),
+                Arguments.of("연령으로 검색",
+                        WebtoonSearchRequest.builder().age(OVER15).sortType(TITLE_ASC).build(),
+                        1, List.of("치즈인더트랩")),
+                Arguments.of("플랫폼으로 검색",
+                        WebtoonSearchRequest.builder().platform(NAVER).sortType(TITLE_ASC).build(),
+                        2, List.of("세기말 풋사과 보습학원", "치즈인더트랩")),
+                Arguments.of("상태로 검색",
+                        WebtoonSearchRequest.builder().status(END).sortType(TITLE_ASC).build(),
+                        1, List.of("치즈인더트랩"))
+        );
+        return argumentsStream;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("searchConditionsProvider")
+    void searchAllByDynamicConditions(String testName,
+                                      WebtoonSearchRequest request,
+                                      int expectedSize,
+                                      List<String> expectedTitles) {
+        // given
+        GenreKeyword genreKeyword1 = createGenreKeyword("일상", "Y");
+        GenreKeyword genreKeyword2 = createGenreKeyword("드라마", "Y");
+        GenreKeyword genreKeyword3 = createGenreKeyword("액션", "Y");
+        genreKeywordRepository.saveAll(List.of(genreKeyword1, genreKeyword2, genreKeyword3));
+
+        Webtoon webtoon1 = createWebtoon("치즈인더트랩", "순끼", OVER15, END, NAVER,
+                List.of(genreKeyword1, genreKeyword2));
+
+        Webtoon webtoon2 = createWebtoon("세기말 풋사과 보습학원", "순끼", ALL, ING, NAVER,
+                List.of(genreKeyword3));
+        webtoonRepository.saveAll(List.of(webtoon1, webtoon2));
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<WebtoonSearchResponse> result = webtoonRepository.searchAll(request, pageable);
+
+        // then
+        assertEquals(expectedSize, result.getTotalElements());
+        if (expectedSize > 0) {
+            // 결과 리스트에서 제목만 추출
+            List<String> actualTitles = result.getContent().stream()
+                    .map(WebtoonSearchResponse::getTitle)
+                    .collect(Collectors.toList());
+
+            // 예상 제목 리스트와 실제 제목 리스트 비교
+            assertEquals(expectedTitles, actualTitles);
+        }
+    }
+
+    @DisplayName("장르 키워드로 웹툰을 조회한다.")
+    @Test
+    void searchAllByGenreKeywords() {
+        // given
+        GenreKeyword genreKeyword1 = createGenreKeyword("일상", "Y");
+        GenreKeyword genreKeyword2 = createGenreKeyword("드라마", "Y");
+        GenreKeyword genreKeyword3 = createGenreKeyword("액션", "Y");
+        genreKeywordRepository.saveAll(List.of(genreKeyword1, genreKeyword2, genreKeyword3));
+
+        Webtoon webtoon1 = createWebtoon("치즈인더트랩", "순끼", OVER15, END, NAVER,
+                List.of(genreKeyword1, genreKeyword2));
+
+        Webtoon webtoon2 = createWebtoon("세기말 풋사과 보습학원", "순끼", ALL, ING, NAVER,
+                List.of(genreKeyword3));
+        webtoonRepository.saveAll(List.of(webtoon1, webtoon2));
+
+        WebtoonSearchRequest request = WebtoonSearchRequest
+                .builder()
+                .genreKeywordIds(List.of(genreKeyword1.getGenreKeywordId(), genreKeyword2.getGenreKeywordId()))
+                .sortType(TITLE_ASC)
+                .build();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<WebtoonSearchResponse> result = webtoonRepository.searchAll(request, pageable);
+
+        // then
+        assertEquals(1, result.getTotalElements());
+        assertEquals("치즈인더트랩", result.getContent().get(0).getTitle());
+    }
+
+    private Webtoon createWebtoon(String title, String author, Age age, WebtoonStatus status,
+                                  Platform platform, List<GenreKeyword> genreKeywords) {
+        return Webtoon.builder()
+                .title(title)
+                .author(author)
+                .age(age)
+                .status(status)
+                .platform(platform)
+                .genreKeywords(genreKeywords)
+                .build();
+    }
+
+    private GenreKeyword createGenreKeyword(String genreKeywordNm, String flag) {
+        return GenreKeyword.builder()
+                .genreKeywordNm(genreKeywordNm)
+                .flag(flag)
+                .build();
+    }
+}

--- a/src/test/java/com/toongather/toongather/domain/webtoon/service/WebtoonServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/service/WebtoonServiceTest.java
@@ -5,6 +5,8 @@ import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
 import com.toongather.toongather.domain.webtoon.repository.GenreKeywordRepository;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
+import com.toongather.toongather.global.common.error.custom.WebtoonException;
+import com.toongather.toongather.global.common.error.custom.WebtoonException.WebtoonNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,7 +24,6 @@ import static com.toongather.toongather.domain.webtoon.domain.Platform.*;
 import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
@@ -149,7 +150,7 @@ class WebtoonServiceTest {
 
         // when & then
         assertThatThrownBy(() -> webtoonService.updateWebtoon(nonExistentToonId, request))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(WebtoonNotFoundException.class)
                 .hasMessage("해당 웹툰이 존재하지 않습니다.");
 
         verify(genreKeywordRepository, never()).findAllByGenreKeywordIdIn(any());
@@ -186,7 +187,7 @@ class WebtoonServiceTest {
 
         // when & then
         assertThatThrownBy(() -> webtoonService.deleteWebtoon(nonExistentToonId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(WebtoonNotFoundException.class)
                 .hasMessage("해당 웹툰이 존재하지 않습니다.");
 
         verify(webtoonRepository).findById(nonExistentToonId);


### PR DESCRIPTION
## 🐞 이슈
- 관련된 이슈 번호: #38 

## 🔨 PR 타입
- [x] ✨ 기능 추가
- [ ] ❌ 기능 삭제
- [ ] 🐛 버그 수정
- [ ] 💡 리팩토링
- [x] 🔧 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내역
- querydsl 설정을 추가했습니다.
- ApiResponse (공통 응답) ok 메서드를 추가했습니다.
- 웹툰 목록 조회 기능을 추가했습니다. (정렬, 조건 검색, 페이징)
- 웹툰 목록 조회 repository 테스트 코드를 추가했습니다. (정렬, 조건 검색, 페이징)
- 정렬에 별점 순, 리뷰 많은 순 등은 디스코드에서 말씀드린 방법으로 따로 구현해서 나중에 추가해두겠습니다 💦💦

## 💡 질문 공유
- 늦어져서 정말로 죄송합니다 흑흑..
- **다른 도메인에서 테스트 코드가 깨지고 있습니다** ..!! ㅠㅠ 기능 수정이나 추가하실 때 테스트 코드도 다시 한 번 돌려보고
수정 부탁 드리겠습니당 🤗🤗

close #38 
