### PR TITLE
[웹툰] 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/toongather/toongather/domain/genrekeyword/domain/GenreKeyword.java
+++ b/src/main/java/com/toongather/toongather/domain/genrekeyword/domain/GenreKeyword.java
@@ -1,4 +1,4 @@
-package com.toongather.toongather.domain.webtoon.domain;
+package com.toongather.toongather.domain.genrekeyword.domain;
 
 import com.toongather.toongather.global.common.BaseEntity;
 import lombok.AccessLevel;

--- a/src/main/java/com/toongather/toongather/domain/genrekeyword/dto/GenreKeywordResponse.java
+++ b/src/main/java/com/toongather/toongather/domain/genrekeyword/dto/GenreKeywordResponse.java
@@ -1,0 +1,27 @@
+package com.toongather.toongather.domain.genrekeyword.dto;
+
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GenreKeywordResponse {
+    private Long genreKeywordId;
+    private String genreKeywordNm;
+    private String flag;
+
+    @Builder
+    private GenreKeywordResponse(Long genreKeywordId, String genreKeywordNm, String flag) {
+        this.genreKeywordId = genreKeywordId;
+        this.genreKeywordNm = genreKeywordNm;
+        this.flag = flag;
+    }
+
+    public static GenreKeywordResponse of(GenreKeyword genreKeyword) {
+        return GenreKeywordResponse.builder()
+                .genreKeywordId(genreKeyword.getGenreKeywordId())
+                .genreKeywordNm(genreKeyword.getGenreKeywordNm())
+                .flag(genreKeyword.getFlag())
+                .build();
+    }
+}

--- a/src/main/java/com/toongather/toongather/domain/genrekeyword/repository/GenreKeywordRepository.java
+++ b/src/main/java/com/toongather/toongather/domain/genrekeyword/repository/GenreKeywordRepository.java
@@ -1,6 +1,6 @@
-package com.toongather.toongather.domain.webtoon.repository;
+package com.toongather.toongather.domain.genrekeyword.repository;
 
-import com.toongather.toongather.domain.webtoon.domain.GenreKeyword;
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/toongather/toongather/domain/webtoon/api/WebtoonController.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/api/WebtoonController.java
@@ -1,9 +1,6 @@
 package com.toongather.toongather.domain.webtoon.api;
 
-import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
+import com.toongather.toongather.domain.webtoon.dto.*;
 import com.toongather.toongather.domain.webtoon.service.WebtoonService;
 import com.toongather.toongather.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +17,13 @@ public class WebtoonController {
     private final WebtoonService webtoonService;
 
     @GetMapping("/search")
-    public ApiResponse<Page<WebtoonSearchResponse>> searchAll(WebtoonSearchRequest request, Pageable pageable) {
-        return ApiResponse.ok("/webtoon/search", webtoonService.searchAll(request, pageable));
+    public ApiResponse<Page<WebtoonSearchResponse>> searchAllWebtoons(WebtoonSearchRequest request, Pageable pageable) {
+        return ApiResponse.ok("/webtoon/search", webtoonService.searchAllWebtoons(request, pageable));
+    }
+
+    @GetMapping("/{toonId}")
+    public ApiResponse<WebtoonResponse> readWebtoon(@PathVariable Long toonId) {
+        return ApiResponse.ok("/webtoon/" + toonId, webtoonService.readWebtoon(toonId));
     }
 
     // todo: @Valid 추가

--- a/src/main/java/com/toongather/toongather/domain/webtoon/domain/Webtoon.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/domain/Webtoon.java
@@ -1,5 +1,6 @@
 package com.toongather.toongather.domain.webtoon.domain;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import com.toongather.toongather.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/toongather/toongather/domain/webtoon/domain/WebtoonGenreKeyword.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/domain/WebtoonGenreKeyword.java
@@ -1,5 +1,6 @@
 package com.toongather.toongather.domain.webtoon.domain;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import com.toongather.toongather.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonRequest.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonRequest.java
@@ -1,5 +1,6 @@
 package com.toongather.toongather.domain.webtoon.dto;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import com.toongather.toongather.domain.webtoon.domain.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonResponse.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonResponse.java
@@ -1,0 +1,55 @@
+package com.toongather.toongather.domain.webtoon.dto;
+
+import com.toongather.toongather.domain.genrekeyword.dto.GenreKeywordResponse;
+import com.toongather.toongather.domain.webtoon.domain.Age;
+import com.toongather.toongather.domain.webtoon.domain.Platform;
+import com.toongather.toongather.domain.webtoon.domain.Webtoon;
+import com.toongather.toongather.domain.webtoon.domain.WebtoonStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class WebtoonResponse {
+    private Long toonId;
+    private String title;
+    private String author;
+    private Age age;
+    private String summary;
+    private WebtoonStatus status;
+    private String imgPath;
+    private Platform platform;
+    private List<GenreKeywordResponse> genreKeywords;
+
+    @Builder
+    public WebtoonResponse(Long toonId, String title, String author, Age age, String summary,
+                           WebtoonStatus status, String imgPath, Platform platform,
+                           List<GenreKeywordResponse> genreKeywords) {
+        this.toonId = toonId;
+        this.title = title;
+        this.author = author;
+        this.age = age;
+        this.summary = summary;
+        this.status = status;
+        this.imgPath = imgPath;
+        this.platform = platform;
+        this.genreKeywords = genreKeywords;
+    }
+
+    public static WebtoonResponse from(Webtoon webtoon) {
+        return WebtoonResponse.builder()
+                .toonId(webtoon.getToonId())
+                .title(webtoon.getTitle())
+                .author(webtoon.getAuthor())
+                .age(webtoon.getAge())
+                .summary(webtoon.getSummary())
+                .status(webtoon.getStatus())
+                .imgPath(webtoon.getImgPath())
+                .platform(webtoon.getPlatform())
+                .genreKeywords(webtoon.getWebtoonGenreKeywords().stream()
+                        .map(webtoonGenreKeyword -> GenreKeywordResponse.of(webtoonGenreKeyword.getGenreKeyword()))
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchResponse.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/dto/WebtoonSearchResponse.java
@@ -21,7 +21,7 @@ public class WebtoonSearchResponse {
         this.imgPath = imgPath;
     }
 
-    public static WebtoonSearchResponse of(Webtoon webtoon) {
+    public static WebtoonSearchResponse from(Webtoon webtoon) {
         return WebtoonSearchResponse.builder()
                 .toonId(webtoon.getToonId())
                 .title(webtoon.getTitle())

--- a/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
+++ b/src/main/java/com/toongather/toongather/domain/webtoon/service/WebtoonService.java
@@ -1,13 +1,10 @@
 package com.toongather.toongather.domain.webtoon.service;
 
 
-import com.toongather.toongather.domain.webtoon.domain.GenreKeyword;
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import com.toongather.toongather.domain.webtoon.domain.Webtoon;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
-import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;
-import com.toongather.toongather.domain.webtoon.repository.GenreKeywordRepository;
+import com.toongather.toongather.domain.webtoon.dto.*;
+import com.toongather.toongather.domain.genrekeyword.repository.GenreKeywordRepository;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
 import com.toongather.toongather.global.common.error.custom.WebtoonException;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +23,15 @@ public class WebtoonService {
     private final GenreKeywordRepository genreKeywordRepository;
     private final WebtoonRepository webtoonRepository;
 
-    public Page<WebtoonSearchResponse> searchAll(WebtoonSearchRequest request, Pageable pageable) {
+    public Page<WebtoonSearchResponse> searchAllWebtoons(WebtoonSearchRequest request, Pageable pageable) {
         return webtoonRepository.searchAll(request, pageable);
+    }
+
+    public WebtoonResponse readWebtoon(Long toonId) {
+        Webtoon webtoon = webtoonRepository.findById(toonId)
+                .orElseThrow(WebtoonException.WebtoonNotFoundException::new);
+
+        return WebtoonResponse.from(webtoon);
     }
 
     @Transactional

--- a/src/test/java/com/toongather/toongather/TestConfig.java
+++ b/src/test/java/com/toongather/toongather/TestConfig.java
@@ -1,10 +1,9 @@
 package com.toongather.toongather;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 public class TestConfig {
     @PersistenceContext

--- a/src/test/java/com/toongather/toongather/domain/webtoon/api/WebtoonControllerTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/api/WebtoonControllerTest.java
@@ -13,12 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.util.List;
-
 import static com.toongather.toongather.domain.webtoon.domain.Age.OVER15;
 import static com.toongather.toongather.domain.webtoon.domain.Platform.DAUM;
 import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.END;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -44,6 +41,20 @@ class WebtoonControllerTest {
         mockMvc = MockMvcBuilders
                 .standaloneSetup(new WebtoonController(webtoonService))
                 .build();
+    }
+
+    @DisplayName("웹툰 상세 조회에 성공한다")
+    @Test
+    void readWebtoon() throws Exception {
+        // given
+        Long toonId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/webtoon/{toonId}", toonId))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(webtoonService, times(1)).readWebtoon(toonId);
     }
 
     @DisplayName("웹툰 등록에 성공한다.")

--- a/src/test/java/com/toongather/toongather/domain/webtoon/domain/WebtoonTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/domain/WebtoonTest.java
@@ -1,5 +1,6 @@
 package com.toongather.toongather.domain.webtoon.domain;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,6 @@ import static com.toongather.toongather.domain.webtoon.domain.Platform.NAVER;
 import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.END;
 import static com.toongather.toongather.domain.webtoon.domain.WebtoonStatus.ING;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class WebtoonTest {
 

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/GenreKeywordRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/GenreKeywordRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.toongather.toongather.domain.webtoon.repository;
 
-import com.toongather.toongather.domain.webtoon.domain.GenreKeyword;
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
+import com.toongather.toongather.domain.genrekeyword.repository.GenreKeywordRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +10,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.jupiter.api.Assertions.*;
 
 class GenreKeywordRepositoryTest extends RepositoryTestSupport {
 

--- a/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/repository/WebtoonRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.toongather.toongather.domain.webtoon.repository;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
+import com.toongather.toongather.domain.genrekeyword.repository.GenreKeywordRepository;
 import com.toongather.toongather.domain.webtoon.domain.*;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchRequest;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonSearchResponse;

--- a/src/test/java/com/toongather/toongather/domain/webtoon/service/WebtoonServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/webtoon/service/WebtoonServiceTest.java
@@ -1,11 +1,12 @@
 package com.toongather.toongather.domain.webtoon.service;
 
+import com.toongather.toongather.domain.genrekeyword.domain.GenreKeyword;
 import com.toongather.toongather.domain.webtoon.domain.*;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonCreateResponse;
 import com.toongather.toongather.domain.webtoon.dto.WebtoonRequest;
-import com.toongather.toongather.domain.webtoon.repository.GenreKeywordRepository;
+import com.toongather.toongather.domain.genrekeyword.repository.GenreKeywordRepository;
+import com.toongather.toongather.domain.webtoon.dto.WebtoonResponse;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
-import com.toongather.toongather.global.common.error.custom.WebtoonException;
 import com.toongather.toongather.global.common.error.custom.WebtoonException.WebtoonNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +41,43 @@ class WebtoonServiceTest {
 
     @Mock
     private GenreKeywordRepository genreKeywordRepository;
+
+    @DisplayName("웹툰 상세 조회에 성공한다.")
+    @Test
+    void readWebtoonSuccess() {
+        // given
+        Long toonId = 1L;
+        Webtoon webtoon = Webtoon.builder()
+                .toonId(toonId)
+                .title("테스트 웹툰")
+                .genreKeywords(List.of(
+                        createGenreKeyword(1L, "로맨스판타지", "Y")
+                ))
+                .build();
+
+        given(webtoonRepository.findById(toonId)).willReturn(Optional.of(webtoon));
+
+        // when
+        WebtoonResponse response = webtoonService.readWebtoon(toonId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getToonId()).isEqualTo(toonId);
+        assertThat(response.getTitle()).isEqualTo("테스트 웹툰");
+    }
+
+    @DisplayName("존재하지 않는 웹툰을 조회하려는 경우 예외가 발생한다.")
+    @Test
+    void readNonExistentWebtoon() {
+        // given
+        Long toonId = 999L;
+        given(webtoonRepository.findById(toonId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> webtoonService.readWebtoon(toonId))
+                .isInstanceOf(WebtoonNotFoundException.class)
+                .hasMessage("해당 웹툰이 존재하지 않습니다.");
+    }
 
     @DisplayName("웹툰 등록에 성공한다.")
     @Test


### PR DESCRIPTION
## 🐞 이슈
- 관련된 이슈 번호: #48 

## 🔨 PR 타입
- [x] ✨ 기능 추가
- [ ] ❌ 기능 삭제
- [ ] 🐛 버그 수정
- [x] 💡 리팩토링
- [ ] 🔧 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내역
- 웹툰 상세 조회 기능을 추가했습니다.
- 웹툰 상세 조회 테스트 코드를 추가했습니다.
- genrekeyword 패키지를 따로 생성했습니다. (webtoon 도메인 아래에 있던 관련 파일들을 모두 옮겼습니다.)
- TestConfig에서 javax를 import하고 있어 오류가 나던 것을 jakarta로 변경하였습니다.

close #48 
