### PR TITLE
[리뷰] 리뷰 키워드 로직 수정 , 리뷰 api 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // classmate 의존성 추가
+    implementation 'com.fasterxml:classmate:1.5.1'
     // oauth2 추가
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 

--- a/src/main/java/com/toongather/toongather/domain/review/api/ReviewController.java
+++ b/src/main/java/com/toongather/toongather/domain/review/api/ReviewController.java
@@ -6,12 +6,14 @@ import com.toongather.toongather.domain.review.dto.CreateReviewRequest;
 import com.toongather.toongather.domain.review.dto.SearchReviewResponse;
 import com.toongather.toongather.domain.review.dto.UpdateReviewRequest;
 import com.toongather.toongather.domain.review.service.ReviewService;
+import com.toongather.toongather.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -20,8 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class ReviewController {
 
-  @Autowired
-  private ReviewService reviewService;
+  private final ReviewService reviewService;
 
   @Value("${file.dir}")
   private String fileDir;
@@ -34,12 +35,20 @@ public class ReviewController {
   }
 
   @PostMapping("/new")
-  public Long saveReview(@RequestBody CreateReviewRequest request) {
-    return reviewService.createReview(request);
+  public ResponseEntity<Long> createReview(@RequestBody CreateReviewRequest request) {
+    return ResponseEntity.ok(reviewService.createReview(request));
   }
 
-  @PostMapping("/{reviewId}")
-  public void updateReview(@RequestBody UpdateReviewRequest request, @PathVariable Long reviewId) {
+  @PutMapping("/{reviewId}")
+  public ResponseEntity<Void> updateReview(@RequestBody UpdateReviewRequest request,
+      @PathVariable Long reviewId) {
     reviewService.updateReview(request);
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
+    reviewService.deleteReview(reviewId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/toongather/toongather/domain/review/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/toongather/toongather/domain/review/dto/UpdateReviewRequest.java
@@ -14,5 +14,5 @@ public class UpdateReviewRequest {
   private Long reviewId;
   private String recommendComment;
   private Long star;
-  private List<String> keywords;
+  //private List<String> keywords;
 }

--- a/src/main/java/com/toongather/toongather/domain/review/service/ReviewService.java
+++ b/src/main/java/com/toongather/toongather/domain/review/service/ReviewService.java
@@ -29,14 +29,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
-
 import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class ReviewService {
 
   @Autowired
@@ -50,9 +49,6 @@ public class ReviewService {
 
   @Autowired
   private MemberService memberService;
-
-  @Autowired
-  private ReviewKeywordService reviewKeywordService;
 
   //@Autowired
   //private FileService fileService;
@@ -145,10 +141,8 @@ public class ReviewService {
 
   @Transactional
   public void deleteReview(Long reviewId) {
-    if (!reviewRepository.existsById(reviewId)) {
-      throw new ReviewNotFoundException();
-    }
-    //reviewKeywordService.deleteByReviewId(reviewId);
+    reviewRepository.findById(reviewId)
+        .orElseThrow(ReviewNotFoundException::new);
     reviewRepository.deleteById(reviewId);
   }
 }

--- a/src/test/java/com/toongather/toongather/TestConfig.java
+++ b/src/test/java/com/toongather/toongather/TestConfig.java
@@ -1,17 +1,18 @@
 package com.toongather.toongather;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 public class TestConfig {
-    @PersistenceContext
-    private EntityManager entityManager;
 
-    @Bean
-    public JPAQueryFactory jpaQueryFactory() {
-        return new JPAQueryFactory(entityManager);
-    }
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
 }

--- a/src/test/java/com/toongather/toongather/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/api/ReviewControllerTest.java
@@ -1,0 +1,176 @@
+package com.toongather.toongather.domain.review.api;
+
+import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.toongather.toongather.domain.review.dto.CreateReviewRequest;
+import com.toongather.toongather.domain.review.dto.UpdateReviewRequest;
+import com.toongather.toongather.domain.review.service.ReviewService;
+import com.toongather.toongather.global.common.error.custom.ReviewException.ReviewNotFoundException;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.Mockito.verify;
+
+import com.toongather.toongather.global.common.advice.ApiExceptionAdvice;
+
+
+@WebMvcTest(ReviewController.class)
+class ReviewControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private ReviewService reviewService;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders
+        .standaloneSetup(new ReviewController(reviewService))
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .setMessageConverters(new MappingJackson2HttpMessageConverter())
+        .alwaysDo(print())
+        .setControllerAdvice(new ApiExceptionAdvice()) // 예외 처리기 추가
+        .build();
+  }
+
+  @DisplayName("리뷰 등록 성공")
+  @Test
+  void createReview() throws Exception {
+    // given
+    CreateReviewRequest request = CreateReviewRequest.builder()
+        .memberId(1L)
+        .toonId(1L)
+        .recommendComment("테스트 리뷰")
+        .star(5L)
+        .build();
+
+    ArgumentCaptor<CreateReviewRequest> captor = ArgumentCaptor.forClass(CreateReviewRequest.class);
+
+    // when & then
+    mockMvc.perform(post("/reviews/new")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+
+    verify(reviewService, times(1)).createReview(captor.capture());
+    CreateReviewRequest captorValue = captor.getValue();
+
+    assertThat(captorValue.getRecommendComment()).isEqualTo("테스트 리뷰");
+    assertThat(captorValue.getStar()).isEqualTo(5L);
+    assertThat(captorValue.getToonId()).isEqualTo(1L);
+    assertThat(captorValue.getMemberId()).isEqualTo(1L);
+  }
+
+  @DisplayName("리뷰 수정 성공")
+  @Test
+  public void updateReview_success() throws Exception {
+    // given
+    Long reviewId = 1L;
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .reviewId(reviewId)
+        .recommendComment("수정된 리뷰")
+        .star(5L)
+        .build();
+
+    ArgumentCaptor<UpdateReviewRequest> captor = ArgumentCaptor.forClass(UpdateReviewRequest.class);
+    willDoNothing().given(reviewService).updateReview(request);
+
+    // when & Then
+    mockMvc.perform(put("/reviews/{reviewId}", reviewId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+    verify(reviewService, times(1)).updateReview(captor.capture());
+
+    UpdateReviewRequest captured = captor.getValue();
+    assertThat(captured.getReviewId()).isEqualTo(reviewId);
+    assertThat(captured.getRecommendComment()).isEqualTo("수정된 리뷰");
+    assertThat(captured.getStar()).isEqualTo(5L);
+  }
+
+  @DisplayName("리뷰 수정 실패")
+  @Test
+  public void updateReview_NotFound() throws Exception {
+    // given
+    Long reviewId = -1L;
+    UpdateReviewRequest request = UpdateReviewRequest.builder()
+        .reviewId(reviewId)
+        .recommendComment("수정 실패 리뷰")
+        .star(4L)
+        .build();
+
+    BDDMockito.willThrow(new ReviewNotFoundException()).given(reviewService)
+        .updateReview(any(UpdateReviewRequest.class));
+
+    // when & then
+    mockMvc.perform(put("/reviews/{reviewId}", reviewId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("해당 리뷰가 존재하지 않습니다."));
+
+    verify(reviewService, times(1)).updateReview(any(UpdateReviewRequest.class));
+  }
+
+  @DisplayName("리뷰 삭제 성공")
+  @Test
+  public void deleteReview_success() throws Exception {
+    // given
+    Long reviewId = 1L;
+    willDoNothing().given(reviewService).deleteReview(reviewId);
+
+    // when
+    mockMvc.perform(delete("/reviews/{reviewId}", reviewId))
+        .andExpect(status().isOk());
+
+    // then
+    verify(reviewService, times(1)).deleteReview(reviewId);
+  }
+
+  @DisplayName("리뷰 삭제 실패")
+  @Test
+  public void deleteReview_NotFound() throws Exception {
+    // given
+    Long reviewId = 1L;
+    willThrow(new ReviewNotFoundException())
+        .given(reviewService).deleteReview(reviewId);
+
+    // when
+    mockMvc.perform(delete("/reviews/{reviewId}", reviewId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value("해당 리뷰가 존재하지 않습니다."));
+
+    // then
+    verify(reviewService, times(1)).deleteReview(reviewId);
+  }
+}

--- a/src/test/java/com/toongather/toongather/domain/review/repository/ReviewKeywordRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/repository/ReviewKeywordRepositoryTest.java
@@ -3,6 +3,7 @@ package com.toongather.toongather.domain.review.repository;
 import static org.assertj.core.api.Assertions.*;
 
 
+import com.toongather.toongather.domain.member.domain.Member;
 import com.toongather.toongather.domain.member.dto.JoinFormRequest;
 import com.toongather.toongather.domain.member.service.EmailService;
 import com.toongather.toongather.domain.member.service.MemberService;
@@ -19,7 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -32,7 +34,7 @@ class ReviewKeywordRepositoryTest {
   WebtoonRepository webtoonRepository;
   @Autowired
   MemberService memberService;
-  @MockBean
+  @MockitoBean
   EmailService emailService;
   @Autowired
   ReviewService reviewService;
@@ -52,7 +54,6 @@ class ReviewKeywordRepositoryTest {
         .star(5L)
         .toonId(w1.getToonId())
         .recommendComment("재밌구만유")
-        .keywords(keywords)
         .build();
 
     Long reviewId = reviewService.createReview(createRequest);
@@ -74,8 +75,8 @@ class ReviewKeywordRepositoryTest {
     joinFormDTO.setNickName("테스트닉네임");
     joinFormDTO.setPassword("1234");
     joinFormDTO.setPhone("010-7666-1111");
-    Long memberId = memberService.join(joinFormDTO);
-    return memberId;
+    Member member = memberService.join(joinFormDTO);
+    return member.getId();
   }
 
   private Webtoon createWebtoon(String title, Long toonId) {

--- a/src/test/java/com/toongather/toongather/domain/review/repository/ReviewRecordRepositoryTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/repository/ReviewRecordRepositoryTest.java
@@ -67,9 +67,9 @@ class ReviewRecordRepositoryTest {
     joinForm.setEmail("younie.jang@gmail.com");
     joinForm.setNickName("test");
     joinForm.setPassword("1234");
-    Long memberId = memberService.join(joinForm);
+    Member member = memberService.join(joinForm);
 
-    Member member = memberService.findMemberEntityById(memberId);
+    Member findmember = memberService.findMemberEntityById(member.getId());
     List<GenreKeyword> genreKeywords = List.of(
         createGenreKeyword(1L, "로맨스판타지", "Y"),
         createGenreKeyword(2L, "드라마", "Y")
@@ -80,7 +80,7 @@ class ReviewRecordRepositoryTest {
     WebtoonCreateResponse webtoonCreateResponse = webtoonService.createWebtoon(request);
     Webtoon webtoon = webtoonRepository.findById(webtoonCreateResponse.getId()).get();
 
-    Review review = Review.createReview(member, webtoon, "테스트 추천 코멘트", 5L);
+    Review review = Review.createReview(findmember, webtoon, "테스트 추천 코멘트", 5L);
     reviewId = reviewService.saveReview(review);
     Review savedReview = reviewService.findById(reviewId);
 

--- a/src/test/java/com/toongather/toongather/domain/review/service/ReviewKeywordServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/service/ReviewKeywordServiceTest.java
@@ -75,33 +75,39 @@ class ReviewKeywordServiceTest {
         .keywords(newKeywords)
         .build();
 
-    given(reviewService.findEntityById(request.getReviewId())).willReturn(mock(Review.class));
+    given(reviewService.findById(request.getReviewId())).willReturn(mock(Review.class));
     given(reviewKeywordRepository.findByReviewReviewId(request.getReviewId()))
         .willReturn(existingReviewKeyword);
 
-    given(keywordService.createKeyword("수정된"))
-        .willReturn(Keyword.builder().keywordNm("수정된").build());
+    given(keywordService.createKeyword("수정된")).willReturn(
+        Keyword.builder().keywordNm("수정된").build());
+    given(keywordService.createKeyword("키워드")).willReturn(
+        Keyword.builder().keywordNm("키워드").build());
 
-    ArgumentCaptor<List<ReviewKeyword>> savedKeywordsCaptor = ArgumentCaptor.forClass(List.class);
-    ArgumentCaptor<List<ReviewKeyword>> deletedKeywordsCaptor = ArgumentCaptor.forClass(List.class);
+    ArgumentCaptor<List<ReviewKeyword>> savedKeywordsCaptor = ArgumentCaptor.forClass(
+        List.class);    // 저장된 키워드
+    ArgumentCaptor<List<ReviewKeyword>> deletedKeywordsCaptor = ArgumentCaptor.forClass(
+        List.class);  // 수정된 키워드
 
     //When
     reviewKeywordService.updateReviewKeyword(request);
 
     //Then
-    verify(reviewService).findEntityById(reviewId);
-    verify(reviewKeywordRepository).findByReviewReviewId(reviewId);
-    verify(reviewKeywordRepository).deleteAll(deletedKeywordsCaptor.capture());
-    verify(reviewKeywordRepository).saveAll(savedKeywordsCaptor.capture());
+    verify(reviewService, only()).findById(reviewId);
+    verify(reviewKeywordRepository, times(1)).findByReviewReviewId(reviewId);
+    verify(reviewKeywordRepository, times(1)).deleteAll(deletedKeywordsCaptor.capture());
+    verify(reviewKeywordRepository, times(1)).saveAll(savedKeywordsCaptor.capture());
 
     List<ReviewKeyword> deleteKeywords = deletedKeywordsCaptor.getValue();
     List<ReviewKeyword> savedKeywords = savedKeywordsCaptor.getValue();
 
     assertThat(deleteKeywords).extracting(
             reviewKeyword -> reviewKeyword.getKeyword().getKeywordNm())
-        .containsExactlyInAnyOrder("기존의");
+        .containsExactlyInAnyOrder("기존의", "키워드");
     assertThat(savedKeywords).extracting(
             reviewKeyword -> reviewKeyword.getKeyword().getKeywordNm())
-        .containsExactlyInAnyOrder("수정된");
+        .containsExactlyInAnyOrder("수정된", "키워드");
   }
+
+  
 }

--- a/src/test/java/com/toongather/toongather/domain/review/service/ReviewRecordServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/service/ReviewRecordServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 
+import com.toongather.toongather.domain.member.domain.Member;
 import com.toongather.toongather.domain.member.dto.JoinFormRequest;
 import com.toongather.toongather.domain.member.service.MemberService;
 import com.toongather.toongather.domain.review.domain.Review;
@@ -49,20 +50,21 @@ class ReviewRecordServiceTest {
   @Test
   public void createReviewRecord() {
     //Given
-    given(memberService.join(any(JoinFormRequest.class))).willReturn(1L);
+    Member member = Member.builder().memberId(1L).build();
+    given(memberService.join(any(JoinFormRequest.class))).willReturn(member);
     given(webtoonService.createWebtoon(any(WebtoonRequest.class)))
         .willReturn(WebtoonCreateResponse.builder().id(1L).build());
 
     Review existReview = Review.builder().reviewId(1L).recommendComment("리뷰 코멘트").build();
     given(reviewService.findById(existReview.getReviewId())).willReturn(existReview);
 
-    Long memberId = memberService.join(new JoinFormRequest());
+    Member findMember = memberService.join(new JoinFormRequest());
     WebtoonCreateResponse webtoonCreateResponse = webtoonService.createWebtoon(
         WebtoonRequest.builder().build());
 
     ReviewRecordRequest createReviewRecordRequest = ReviewRecordRequest.builder()
         .reviewId(existReview.getReviewId())
-        .memberId(memberId)
+        .memberId(findMember.getId())
         .record("리뷰 있는 기록 저장 테스트")
         .toonId(webtoonCreateResponse.getId())
         .build();
@@ -87,18 +89,19 @@ class ReviewRecordServiceTest {
   @Test
   public void createReviewRecordNoReview() {
     //Given
-    given(memberService.join(any(JoinFormRequest.class))).willReturn(1L);
+    Member member = Member.builder().memberId(1L).build();
+    given(memberService.join(any(JoinFormRequest.class))).willReturn(member);
     given(webtoonService.createWebtoon(any(WebtoonRequest.class)))
         .willReturn(WebtoonCreateResponse.builder().id(1L).build());
     given(reviewService.createDefaultReview(any(Long.class), any(Long.class)))
         .willReturn(Review.builder().reviewId(1L).build());
 
-    Long memberId = memberService.join(new JoinFormRequest());
+    Member findMember = memberService.join(new JoinFormRequest());
     WebtoonCreateResponse webtoonCreateResponse = webtoonService.createWebtoon(
         WebtoonRequest.builder().build());
 
     ReviewRecordRequest createReviewRecordRequest = ReviewRecordRequest.builder()
-        .memberId(memberId)
+        .memberId(findMember.getId())
         .reviewId(null)
         .record("리뷰 없는 기록 저장 테스트")
         .toonId(webtoonCreateResponse.getId())

--- a/src/test/java/com/toongather/toongather/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/toongather/toongather/domain/review/service/ReviewServiceTest.java
@@ -16,6 +16,7 @@ import com.toongather.toongather.domain.webtoon.domain.Webtoon;
 import com.toongather.toongather.domain.webtoon.repository.WebtoonRepository;
 
 import com.toongather.toongather.domain.webtoon.service.WebtoonService;
+import com.toongather.toongather.global.common.error.custom.ReviewException.ReviewNotFoundException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -215,7 +216,7 @@ public class ReviewServiceTest {
   public void deleteReview() {
     //Given
     Long reviewId = 1L;
-    given(reviewRepository.existsById(reviewId)).willReturn(true);
+    given(reviewRepository.findById(reviewId)).willReturn(Optional.of(any(Review.class)));
 
     //When
     reviewService.deleteReview(reviewId);
@@ -224,17 +225,17 @@ public class ReviewServiceTest {
     verify(reviewRepository, times(1)).deleteById(reviewId);
   }
 
-  @DisplayName("리뷰가 없는 경우, 리뷰 삭제 시 NoSuchElementException 예외발생")
+  @DisplayName("리뷰가 없는 경우, 리뷰 삭제 시 ReviewNotFoundException 예외발생")
   @Test
   public void deleteReviewNonExistReview() {
     //Given
     Long nonExistentReviewId = 1L;
-    given(reviewRepository.existsById(nonExistentReviewId)).willReturn(false);
+    given(reviewRepository.findById(nonExistentReviewId)).willReturn(Optional.empty());
 
     //When&then
     assertThatThrownBy(() -> reviewService.deleteReview(nonExistentReviewId))
-        .isInstanceOf(NoSuchElementException.class)
-        .hasMessageContaining("삭제 할 리뷰가 없습니다.");
+        .isInstanceOf(ReviewNotFoundException.class)
+        .hasMessageContaining("해당 리뷰가 존재하지 않습니다.");
   }
 
 }


### PR DESCRIPTION
## 🐞 이슈
- #46 

## 🔨 PR 타입
- [x] ✨ 기능 추가
- [ ] ❌ 기능 삭제
- [ ] 🐛 버그 수정
- [x] 💡 리팩토링
- [ ] 🔧 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 작업 내역
- 키워드 로직 수정
  : 기존에는 변경된 키워드만 수정하게 되어 있었는데 키워드 전체 삭제하고 다시 생성하는 로직으로 수정
- 리뷰 api 개발

p.s 저번에 해림 선임님이 reviewRecord 너무 엮여 있다고 얘기하셨었는데 생각 해 보니까 
 굳이 review하고 연관 관계 안 맺어도 될 것 같은데 Record 도메인으로 빼고 웹툰, 멤버 하고 만 연관 맺으면 될 것 같은데
 어떻게 생각하시나요?)
close
